### PR TITLE
Missing $options variable

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -58,6 +58,11 @@ class Widget extends \yii\base\Widget
      * @var string the Json encoded options
      */
     protected $_encOptions = '';
+    
+    /**
+     * @var array various options needed for widgets
+     */
+    public $options = [];
 
     /**
      * Initialize the widget


### PR DESCRIPTION
Bugfix for missing options variable(needed by widgets such as Sortable, DynaGrid)
