### PR TITLE
Bug in class InputWidget in Method setLanguage

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,3 +1,9 @@
+version 1.6.0
+=============
+**Date:** 11-Dec-2014
+
+- (bug #16): variable `$short` in `InputWidget` in method `setLanguage` set without `$prefix`.
+
 version 1.5.0
 =============
 **Date:** 06-Dec-2014

--- a/InputWidget.php
+++ b/InputWidget.php
@@ -182,7 +182,7 @@ class InputWidget extends \yii\widgets\InputWidget
         }
         $full = $filePath . $prefix . $this->language . $suffix;
         $fullLower = $filePath . $prefix . strtolower($this->language) . $suffix;
-        $short = $filePath . $this->_lang . $suffix;
+        $short = $filePath . $prefix . $this->_lang . $suffix;
         if (Config::fileExists($assetPath . $full)) {
             $this->_langFile = $full;
             $this->pluginOptions['language'] = $this->language;


### PR DESCRIPTION
The method `setLanguage`in InputWidget produce different localized languages files and checks which is really existing. The version for variable `$short` is wrongly concatenated. The part of `$prefix` is missed. Most language files uses the short version.
