### PR TITLE
Wrong namespace for FileInput widget

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -52,7 +52,7 @@ class Config
         '\kartik\touchspin\TouchSpin' => ['yii2-widgets', 'yii2-widget-touchspin'],
         '\kartik\switchinput\SwitchInput' => ['yii2-widgets', 'yii2-widget-switchinput'],
         '\kartik\rating\StarRating' => ['yii2-widgets', 'yii2-widget-rating'],
-        '\kartik\rating\FileInput' => ['yii2-widgets', 'yii2-widget-fileinput'],
+        '\kartik\file\FileInput' => ['yii2-widgets', 'yii2-widget-fileinput'],
         '\kartik\range\RangeInput' => ['yii2-widgets', 'yii2-widget-rangeinput'],
         '\kartik\color\ColorInput' => ['yii2-widgets', 'yii2-widget-colorinput'],
         '\kartik\date\DatePicker' => ['yii2-widgets', 'yii2-widget-datepicker'],


### PR DESCRIPTION
It seems that it is a result of copypasting - should be `\kartik\file\FileInput` instead of `\kartik\rating\FileInput`
