### PR TITLE
Adding support of array attributes

### DIFF
--- a/Html5Input.php
+++ b/Html5Input.php
@@ -134,7 +134,7 @@ class Html5Input extends InputWidget
         }
         Html::addCssClass($this->html5Container, 'input-group-addon addon-' . $this->type);
         $caption = $this->getInput('textInput');
-        $value = $this->hasModel() ? $this->model[Html::getAttributeName($this->attribute)] : $this->value;
+        $value = $this->hasModel() ? Html::getAttributeValue($this->model, $this->attribute) : $this->value;
         $input = Html::input($this->type, $this->html5Options['id'], $value, $this->html5Options);
         $prepend = static::getAddonContent(ArrayHelper::getValue($this->addon, 'prepend', ''));
         $append = static::getAddonContent(ArrayHelper::getValue($this->addon, 'append', ''));

--- a/InputWidget.php
+++ b/InputWidget.php
@@ -144,7 +144,7 @@ class InputWidget extends \yii\widgets\InputWidget
         if ($this->hasModel()) {
             $this->name = empty($this->options['name']) ? Html::getInputName($this->model,
                 $this->attribute) : $this->options['name'];
-            $this->value = $this->model[Html::getAttributeName($this->attribute)];
+            $this->value = Html::getAttributeValue($this->model, $this->attribute);
         }
         $this->initDisability($this->options);
         $view = $this->getView();


### PR DESCRIPTION
I would like to add support of input attribute being an array element. 
This is supported by Yii:BaseHtml input widgets. 

Example: 
echo $form->field($model, 'styleArray[borderColor]')->widget(\kartik\widgets\ColorInput::classname(),...

This is especially useful whan many form inputs and not always the same.