### PR TITLE
Fix for bug with PHP date format when convertFormat=true and widget format is not set

### DIFF
--- a/InputWidget.php
+++ b/InputWidget.php
@@ -320,7 +320,7 @@ class InputWidget extends \yii\widgets\InputWidget
         }
         $attrib = $type . 'Format';
         $format = isset(Yii::$app->formatter->$attrib) ? Yii::$app->formatter->$attrib : '';
-        if (isset($this->dateFormat) && strncmp($this->dateFormat, 'php:', 4) === 0) {
+        if (isset($format) && strncmp($format, 'php:', 4) === 0) {
             $this->pluginOptions['format'] = static::convertDateFormat(substr($format, 4));
         } elseif ($format != '') {
             $format = FormatConverter::convertDateIcuToPhp($format, $type);


### PR DESCRIPTION
Problem: when `DatePicker` is configured with `convertFormat=true`, `format` not specified and `Yii::$app->formatter` specified the date in PHP format (for ex. 'php:Y-m-d'), the DatePicker incorrectly calls convertDateIcuToPhp() on that PHP format.

This happens due to the condition `if (isset($this->dateFormat) ... )` being always false, because the `$dateFormat` field does not exist (and never set) in both `InputWidget` and `DatePicker` classes. The local variable `$format` should have been used in the `if` instead.