### PR TITLE
DatePicker is not init after Pjax is loading

### DIFF
--- a/WidgetTrait.php
+++ b/WidgetTrait.php
@@ -193,7 +193,7 @@ trait WidgetTrait
         if (!empty($this->pjaxContainerId) && ($pos === View::POS_LOAD || $pos === View::POS_READY)) {
             $pjax = 'jQuery("#' . $this->pjaxContainerId . '")';
             $evComplete = 'pjax:complete.' . hash('crc32', $js);
-            $view->registerJs("{$pjax}.off('{$evComplete}').on('{$evComplete}',function(){ {$js} });");
+            $view->registerJs("{$pjax}.off('{$evComplete}').on('{$evComplete}',function(){ setTimeout(function(){ {$js} }, 100); });");
             // hack fix for browser back and forward buttons
             if ($this->enablePopStateFix) {
                 $view->registerJs("window.addEventListener('popstate',function(){window.location.reload();});");


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-krajee-base/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.
Bugfix: DatePicker is not init after Pjax is loading