### PR TITLE
Update Config.php

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -65,7 +65,7 @@ class Config
         '\kartik\sortinput\SortableInput' => 'yii2-sortinput',
         '\kartik\tree\TreeViewInput' => 'yii2-tree-manager',
         '\kartik\money\MaskMoney' => 'yii2-money',
-        '\kartik\checkbox\CheckboxX' => 'yii2-checkbox',
+        '\kartik\checkbox\CheckboxX' => 'yii2-checkbox-x',
         '\kartik\slider\Slider' => 'yii2-slider',
     ];
 
@@ -106,7 +106,7 @@ class Config
             return;
         }
         $command = 'php composer.phar require ' . self::VENDOR_NAME;
-        $version = ': \'@dev\'';
+        $version = ' \'@dev\'';
         $class = (substr($name, 0, 8) == self::NAMESPACE_PREFIX) ? $name : self::NAMESPACE_PREFIX . $name;
 
         if (is_array($repo)) {


### PR DESCRIPTION
On error:

> Invalid Configuration – yii\base\InvalidConfigException
> 
> The class '\kartik\checkbox\CheckboxX' was not found and is required for your selected functionality.
> 
> Please ensure you have installed the 'yii2-checkbox' extension. To install, you can run this console command from your application root:
> 
> php composer.phar require kartik-v/yii2-checkbox: '@dev'

- Updated to new checkbox-x package name
- Removed `:` from composer command, which causes to fail

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation