### PR TITLE
About usage pjaxContainerId 

### DIFF
--- a/src/InputWidget.php
+++ b/src/InputWidget.php
@@ -120,6 +120,7 @@ class InputWidget extends YiiInputWidget
     /**
      * @var string a pjax container identifier if applicable inside which the widget will be rendered. If this is set,
      * the widget will automatically reinitialize on pjax render completion.
+     * tip: also acceptable any parent (to pjax container) node id
      */
     public $pjaxContainerId;
 

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -77,6 +77,7 @@ class Widget extends YiiWidget
     /**
      * @var string a pjax container identifier if applicable inside which the widget will be rendered. If this is set,
      * the widget will automatically reinitialize on pjax render completion.
+     * tip: also acceptable any parent (to pjax container) node id
      */
     public $pjaxContainerId;
 


### PR DESCRIPTION
We can use this property also if we have non-id-defined pjax. Just use a closest outer container who have id.

## Scope
This pull request includes a
- [x] Hint
- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-krajee-base/blob/master/CHANGE.md)):

## Related Issues
If this is related to an existing ticket, include a link to it as well.