### PR TITLE
Fix #95 Class was composed

### DIFF
--- a/src/InputWidget.php
+++ b/src/InputWidget.php
@@ -59,11 +59,6 @@ class InputWidget extends YiiInputWidget
     const LOAD_PROGRESS = '<div class="kv-plugin-loading">&nbsp;</div>';
 
     /**
-     * @var string the name of the jQuery plugin.
-     */
-    public $pluginName = '';
-
-    /**
      * @var string the language configuration (e.g. 'fr-FR', 'zh-CN'). The format for the language/locale is
      * ll-CC where ll is a two or three letter lowercase code for a language according to ISO-639 and
      * CC is the country code according to ISO-3166.


### PR DESCRIPTION
## Scope

kartik\base\InputWidget and kartik\base\WidgetTrait define the same property ($pluginName) in the composition of kartik\base\InputWidget. However, the definition differs and is considered incompatible. Class was composed

## Related Issues

Fix for issue #95